### PR TITLE
Fix TypeError due to slice input

### DIFF
--- a/src/SOAPpy/Types.py
+++ b/src/SOAPpy/Types.py
@@ -1451,6 +1451,8 @@ class arrayType(collections.UserList, compoundType):
     def __getitem__(self, item):
         try:
             return self.data[int(item)]
+        except TypeError:
+            return self.data[item]
         except ValueError:
             return getattr(self, item)
 


### PR DESCRIPTION
Getting TypeError due to slice (eg. item is data[1:])

Also, i needed this change too due as Python3 now expects True for __bool__
* https://github.com/Synerty/SOAPpy-py3/pull/3/commits/a1eb7c0cc431e79a4000708fd2aecfa4b8807bfc
