### PR TITLE
Fix the 0.52.29 package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,4 @@ include-package-data = true
 provides = ["SOAPpy"]
 
 [tool.setuptools.packages]
-find = {namespaces = false}
+find = {namespaces = false, where = ["src"]}


### PR DESCRIPTION
Without this change, there tarball doesn't include the SOAPpy code at all and the package is broken.

On 0.52.29 the following happens:

```
--> pip install SOAPpy-py3-0.52.29.tar.gz

Processing ./SOAPpy-py3-0.52.29.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Collecting wstools-py3
  Using cached wstools_py3-0.54.5-py2.py3-none-any.whl
Collecting defusedxml
  Using cached defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
Collecting six
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Building wheels for collected packages: SOAPpy-py3
  Building wheel for SOAPpy-py3 (pyproject.toml) ... done
  Created wheel for SOAPpy-py3: filename=SOAPpy_py3-0.52.29-py3-none-any.whl size=2715 sha256=b62bf4791a35223875d07a58f3722d96eebb3c1576592ec4d51d29c4927fab9e
  Stored in directory: /root/.cache/pip/wheels/c7/fb/88/3fe8722ab0ef8fa9061945f4495874f237ca02b71f1df70c26
Successfully built SOAPpy-py3
Installing collected packages: six, defusedxml, wstools-py3, SOAPpy-py3
Successfully installed SOAPpy-py3-0.52.29 defusedxml-0.7.1 six-1.16.0 wstools-py3-0.54.5
```

and then:
```
Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import SOAPpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'SOAPpy'
```