### PR TITLE
Replace obsolete string.join with ''.join

### DIFF
--- a/src/SOAPpy/Parser.py
+++ b/src/SOAPpy/Parser.py
@@ -6,7 +6,6 @@ from .NS        import NS
 from .Utilities import *
 import six
 
-import string
 import xml.sax
 from wstools.XMLname import fromXMLname
 import collections
@@ -222,7 +221,7 @@ class SOAPParser(xml.sax.handler.ContentHandler):
             if href:
                 if href[0] != '#':
                     raise Error("Non-local hrefs are not yet suppported.")
-                if self._data != None and string.join(self._data, "").strip() != '':
+                if self._data != None and "".join(self._data).strip() != '':
                     raise Error("hrefs can't have data")
 
                 href = href[1:]
@@ -334,14 +333,14 @@ class SOAPParser(xml.sax.handler.ContentHandler):
 
 # XXX What if rule != kind?
                 if isinstance(rule, collections.Callable):
-                    data = rule(string.join(self._data, ""))
+                    data = rule("".join(self._data))
                 elif type(rule) == DictType:
                     data = structType(name = (ns, name), attrs = attrs)
                 elif rule[1][:9] == 'arrayType':
                     data = self.convertType(cur.contents,
                                             rule, attrs)
                 else:
-                    data = self.convertType(string.join(self._data, ""),
+                    data = self.convertType("".join(self._data),
                                             rule, attrs)
 
                 break


### PR DESCRIPTION
`sting.join` is not a thing since a long time. Replace it with `"".join` otherwise this exception is raised

```
File "/some/path/lib/python3.11/site-packages/SOAPpy/Parser.py", line 1095, in _parseSOAP
parser.parse(inpsrc)
File "/usr/lib/python3.11/xml/sax/expatreader.py", line 111, in parse
xmlreader.IncrementalParser.parse(self, source)
File "/usr/lib/python3.11/xml/sax/xmlreader.py", line 125, in parse
self.feed(buffer)
File "/usr/lib/python3.11/xml/sax/expatreader.py", line 217, in feed
self._parser.Parse(data, isFinal)
File "../Modules/pyexpat.c", line 468, in EndElement
File "/usr/lib/python3.11/xml/sax/expatreader.py", line 381, in end_element_ns
self._cont_handler.endElementNS(pair, None)
File "/some/path/lib/python3.11/site-packages/SOAPpy/Parser.py", line 232, in endElementNS
string.join(self._data, "").strip() != '':
AttributeError: module 'string' has no attribute 'join'
```